### PR TITLE
fix(partition): wipe partitions after creating incase of corrupted disks

### DIFF
--- a/pkg/device/device-util.go
+++ b/pkg/device/device-util.go
@@ -106,7 +106,10 @@ func wipefsAndCreatePart(disk string, start uint64, partitionName string, size u
 	err = wipeFsPartition(pList[0].DiskName, pList[0].PartNum)
 	if err != nil {
 		klog.Infof("Deleting partition %d on disk %s because wipefs failed", pList[0].PartNum, pList[0].DiskName)
-		_ = deletePartition(pList[0].DiskName, pList[0].PartNum)
+		err1 := deletePartition(pList[0].DiskName, pList[0].PartNum)
+		if err1 != nil {
+			klog.Errorf("could not delete partition %d on disk %s, created during CreateVolume(). Error: %s", pList[0].PartNum, pList[0].DiskName, err1)
+		}
 		// the error will be returned irrespective of the return value of delete partition,
 		// as create partition has failed.
 		return err

--- a/pkg/device/device-util.go
+++ b/pkg/device/device-util.go
@@ -39,7 +39,7 @@ const (
 	PartitionPrint     = "parted /dev/%s unit b print --script"
 	PartitionCreate    = "parted /dev/%s mkpart %s %dMiB %dMiB --script"
 	PartitionDelete    = "parted /dev/%s rm %d --script"
-	PartitionWipeFS    = "wipefs --force -a /dev/%s%d"
+	PartitionWipeFS    = "wipefs --force -a %s"
 )
 
 type partUsed struct {
@@ -104,7 +104,7 @@ func wipefsAndCreatePart(disk string, start uint64, partitionName string, size u
 	}
 
 	klog.Infof("Running WipeFS for Partition %s %d", pList[0].DiskName, pList[0].PartNum)
-	_, err = RunCommand(strings.Split(fmt.Sprintf(PartitionWipeFS, pList[0].DiskName, pList[0].PartNum), " "))
+	_, err = RunCommand(strings.Split(fmt.Sprintf(PartitionWipeFS, getPartitionPath(pList[0].DiskName, pList[0].PartNum)), " "))
 	if err != nil {
 		klog.Errorf("WipeFS failed %s", err)
 		return err
@@ -203,7 +203,7 @@ func DestroyVolume(vol *apis.DeviceVolume) error {
 
 // DeletePart Todo
 func wipefsAndDeletePart(disk string, partNum uint32) error {
-	_, err := RunCommand(strings.Split(fmt.Sprintf(getPartitionPath(disk, partNum), disk, partNum), " "))
+	_, err := RunCommand(strings.Split(fmt.Sprintf(PartitionWipeFS, getPartitionPath(disk, partNum)), " "))
 	if err != nil {
 		klog.Errorf("WipeFS failed %s", err)
 		return err

--- a/pkg/device/device-util.go
+++ b/pkg/device/device-util.go
@@ -106,7 +106,10 @@ func wipefsAndCreatePart(disk string, start uint64, partitionName string, size u
 	err = wipeFsPartition(pList[0].DiskName, pList[0].PartNum)
 	if err != nil {
 		klog.Infof("Deleting partition %d on disk %s because wipefs failed", pList[0].PartNum, pList[0].DiskName)
-		return deletePartition(pList[0].DiskName, pList[0].PartNum)
+		_ = deletePartition(pList[0].DiskName, pList[0].PartNum)
+		// the error will be returned irrespective of the return value of delete partition,
+		// as create partition has failed.
+		return err
 	}
 	return nil
 }


### PR DESCRIPTION
run `wipefs` on partitions that are created so that any stale filesystem headers are removed before a volume uses the partition.