### PR TITLE
fix(workflow): use v1 version of docker meta action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -116,7 +116,7 @@ jobs:
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v1
         with:
           # add each registry to which the image needs to be pushed here
           images: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v1
         with:
           # add each registry to which the image needs to be pushed here
           images: |


### PR DESCRIPTION
- use v1 version of docker meta action in build and release workflow

Signed-off-by: Akhil Mohan <akhil.mohan@mayadata.io>