### PR TITLE
fix(cas): add cas-type key for device under volume attributes

### DIFF
--- a/pkg/device/volume.go
+++ b/pkg/device/volume.go
@@ -50,6 +50,10 @@ const (
 	DeviceStatusFailed string = "Failed"
 	// DeviceStatusReady shows object has been processed
 	DeviceStatusReady string = "Ready"
+	// OpenEBSCasTypeKey for the cas-type label
+	OpenEBSCasTypeKey string = "openebs.io/cas-type"
+	// LocalDeviceCasTypeName for the name of the cas-type
+	LocalDeviceCasTypeName string = "localpv-device"
 )
 
 var (

--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -301,7 +301,7 @@ func (cs *controller) CreateVolume(
 	}
 
 	topology := map[string]string{device.DeviceTopologyKey: vol.Spec.OwnerNodeID}
-	cntx := map[string]string{device.DeviceNameKey: params.DeviceName}
+	cntx := map[string]string{device.DeviceNameKey: params.DeviceName, device.OpenEBSCasTypeKey: device.LocalDeviceCasTypeName}
 
 	return csipayload.NewCreateVolumeResponseBuilder().
 		WithName(volName).


### PR DESCRIPTION
Signed-off-by: Abhinandan-Purkait <abhinandan.purkait@mayadata.io>

**Why is this PR required? What issue does it fix?**:
- LocalPV Device currently does not have any cas-type label to indicate its cas-type.

**What this PR does?**:
- This PR adds the cas-type label to the volume attributes. 