### PR TITLE
fix(device): add check for created partition

### DIFF
--- a/pkg/device/device-util.go
+++ b/pkg/device/device-util.go
@@ -121,6 +121,10 @@ func wipefsAndCreatePart(disk string, start uint64, partitionName string, size u
 		return err
 	}
 
+	if len(pList) == 0 {
+		return fmt.Errorf("could not find created partition %s", partitionName)
+	}
+
 	err = wipeFsPartition(pList[0].DiskName, pList[0].PartNum)
 	if err != nil {
 		klog.Infof("Deleting partition %d on disk %s because wipefs failed", pList[0].PartNum, pList[0].DiskName)


### PR DESCRIPTION
- add additional check for the created partition before performing wipefs

Fix in part: https://github.com/openebs/device-localpv/issues/20

Signed-off-by: Akhil Mohan <akhil.mohan@mayadata.io>