### PR TITLE
fix(volume): set threadiness to 1 for volume workers

### DIFF
--- a/pkg/mgmt/volume/start.go
+++ b/pkg/mgmt/volume/start.go
@@ -86,7 +86,7 @@ func Start(controllerMtx *sync.RWMutex, stopCh <-chan struct{}) error {
 	go VolInformerFactory.Start(stopCh)
 
 	// Threadiness defines the number of workers to be launched in Run function
-	return controller.Run(2, stopCh)
+	return controller.Run(1, stopCh)
 }
 
 // GetClusterConfig return the config for k8s.

--- a/pkg/mgmt/volume/start.go
+++ b/pkg/mgmt/volume/start.go
@@ -86,6 +86,10 @@ func Start(controllerMtx *sync.RWMutex, stopCh <-chan struct{}) error {
 	go VolInformerFactory.Start(stopCh)
 
 	// Threadiness defines the number of workers to be launched in Run function
+	// The no.of threads is set to 1 here as using `parted` command for creation/deletion
+	// of partitions from multiple threads can lead to race condition and eventually some
+	// partitions not getting cleaned up from the disk.
+	// Ref: https://github.com/openebs/device-localpv/issues/21
 	return controller.Run(1, stopCh)
 }
 


### PR DESCRIPTION
- set no of threads for volume workers to 1 to avoid race condition
while deleting partitions using parted

Signed-off-by: Akhil Mohan <akhil.mohan@mayadata.io>