### PR TITLE
fix(deploy): Pass listen-address flag for exporter and add service yaml

### DIFF
--- a/deploy/device-operator.yaml
+++ b/deploy/device-operator.yaml
@@ -570,7 +570,6 @@ metadata:
   name: openebs-device-node-service
   labels:
     name: openebs-device-node
-    openebs.io/storage-engine-type: LocalPV
 spec:
   clusterIP: None
   ports:

--- a/deploy/device-operator.yaml
+++ b/deploy/device-operator.yaml
@@ -241,6 +241,23 @@ status:
 
 ---
 
+apiVersion: v1
+kind: Service
+metadata:
+  name: openebs-device-node-service
+  labels:
+    name: openebs-device-node
+spec:
+  clusterIP: None
+  ports:
+    - name: metrics
+      port: 9501
+      targetPort: 9501
+  selector:
+    app: openebs-device-node
+
+---
+
 # Create the CSI Driver object
 apiVersion: storage.k8s.io/v1beta1
 kind: CSIDriver
@@ -562,19 +579,3 @@ spec:
           hostPath:
             path: /var/lib/kubelet/
             type: Directory
----
-
-apiVersion: v1
-kind: Service
-metadata:
-  name: openebs-device-node-service
-  labels:
-    name: openebs-device-node
-spec:
-  clusterIP: None
-  ports:
-    - name: metrics
-      port: 9501
-      targetPort: 9501
-  selector:
-    app: openebs-device-node

--- a/deploy/device-operator.yaml
+++ b/deploy/device-operator.yaml
@@ -521,6 +521,7 @@ spec:
             - "--nodeid=$(OPENEBS_NODE_ID)"
             - "--endpoint=$(OPENEBS_CSI_ENDPOINT)"
             - "--plugin=$(OPENEBS_NODE_DRIVER)"
+            - "--listen-address=$(METRICS_LISTEN_ADDRESS)"
           env:
             - name: OPENEBS_NODE_ID
               valueFrom:
@@ -532,6 +533,8 @@ spec:
               value: agent
             - name: DEVICE_DRIVER_NAMESPACE
               value: openebs
+            - name: METRICS_LISTEN_ADDRESS
+              value: :9501
           volumeMounts:
             - name: plugin-dir
               mountPath: /plugin
@@ -560,3 +563,19 @@ spec:
             path: /var/lib/kubelet/
             type: Directory
 ---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: openebs-device-node-service
+  labels:
+    name: openebs-device-node
+    openebs.io/storage-engine-type: LocalPV
+spec:
+  clusterIP: None
+  ports:
+    - name: metrics
+      port: 9501
+      targetPort: 9501
+  selector:
+    app: openebs-device-node

--- a/deploy/yamls/device-driver.yaml
+++ b/deploy/yamls/device-driver.yaml
@@ -281,6 +281,7 @@ spec:
             - "--nodeid=$(OPENEBS_NODE_ID)"
             - "--endpoint=$(OPENEBS_CSI_ENDPOINT)"
             - "--plugin=$(OPENEBS_NODE_DRIVER)"
+            - "--listen-address=$(METRICS_LISTEN_ADDRESS)"
           env:
             - name: OPENEBS_NODE_ID
               valueFrom:
@@ -292,6 +293,8 @@ spec:
               value: agent
             - name: DEVICE_DRIVER_NAMESPACE
               value: openebs
+            - name: METRICS_LISTEN_ADDRESS
+              value: :9501
           volumeMounts:
             - name: plugin-dir
               mountPath: /plugin
@@ -320,3 +323,19 @@ spec:
             path: /var/lib/kubelet/
             type: Directory
 ---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: openebs-device-node-service
+  labels:
+    name: openebs-device-node
+    openebs.io/storage-engine-type: LocalPV
+spec:
+  clusterIP: None
+  ports:
+    - name: metrics
+      port: 9501
+      targetPort: 9501
+  selector:
+    app: openebs-device-node

--- a/deploy/yamls/device-driver.yaml
+++ b/deploy/yamls/device-driver.yaml
@@ -1,6 +1,23 @@
 
 ---
 
+apiVersion: v1
+kind: Service
+metadata:
+  name: openebs-device-node-service
+  labels:
+    name: openebs-device-node
+spec:
+  clusterIP: None
+  ports:
+    - name: metrics
+      port: 9501
+      targetPort: 9501
+  selector:
+    app: openebs-device-node
+
+---
+
 # Create the CSI Driver object
 apiVersion: storage.k8s.io/v1beta1
 kind: CSIDriver
@@ -322,19 +339,3 @@ spec:
           hostPath:
             path: /var/lib/kubelet/
             type: Directory
----
-
-apiVersion: v1
-kind: Service
-metadata:
-  name: openebs-device-node-service
-  labels:
-    name: openebs-device-node
-spec:
-  clusterIP: None
-  ports:
-    - name: metrics
-      port: 9501
-      targetPort: 9501
-  selector:
-    app: openebs-device-node

--- a/deploy/yamls/device-driver.yaml
+++ b/deploy/yamls/device-driver.yaml
@@ -330,7 +330,6 @@ metadata:
   name: openebs-device-node-service
   labels:
     name: openebs-device-node
-    openebs.io/storage-engine-type: LocalPV
 spec:
   clusterIP: None
   ports:


### PR DESCRIPTION
Signed-off-by: Sahil Raja <sahilraja242@gmail.com>

- Pass listen-address flag value through arguments.
   -  `listen-address= :9501`   
- Add configuration for service yaml which needs to be installed when the exporter is enabled.