### PR TITLE
fix(provisioning): remove Gi unit conversion for pv capacity

### DIFF
--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -97,16 +97,6 @@ var SupportedVolumeCapabilityAccessModes = []*csi.VolumeCapability_AccessMode{
 
 // getRoundedCapacity rounds the capacity on 1024 base
 func getRoundedCapacity(size int64) int64 {
-
-	/*
-	 * volblocksize and recordsize must be power of 2 from 512B to 1M
-	 * so keeping the size in the form of Gi or Mi should be
-	 * sufficient to make volsize multiple of volblocksize/recordsize.
-	 */
-	if size > Gi {
-		return ((size + Gi - 1) / Gi) * Gi
-	}
-
 	// Keeping minimum allocatable size as 1Mi (1024 * 1024)
 	return ((size + Mi - 1) / Mi) * Mi
 }
@@ -569,6 +559,8 @@ func (cs *controller) GetCapacity(
 		}
 	}
 
+	// round off the available capacity to indicate allocatable vol size correctly.
+	availableCapacity = (availableCapacity / Mi) * Mi
 	return &csi.GetCapacityResponse{
 		AvailableCapacity: availableCapacity,
 	}, nil

--- a/pkg/driver/controller_test.go
+++ b/pkg/driver/controller_test.go
@@ -31,10 +31,8 @@ func TestRoundOff(t *testing.T) {
 		"Minimum allocatable is 1Mi": {input: 1, expected: Mi},
 		"roundOff to same Mi size":   {input: Mi, expected: Mi},
 		"roundOff to nearest Mi":     {input: Mi + 1, expected: Mi * 2},
-		"roundOff to same Gi size":   {input: Gi, expected: Gi},
-		"roundOff to nearest Gi":     {input: Gi + 1, expected: Gi * 2},
 		"roundOff MB size":           {input: 5 * MB, expected: 5 * Mi},
-		"roundOff GB size":           {input: 5 * GB, expected: 5 * Gi},
+		"roundOff Gi size":           {input: Gi + 512, expected: Gi + Mi},
 	}
 
 	for name, test := range tests {


### PR DESCRIPTION
Kept the volume capacity as multiple of mebibyte for block alignment that [we have at node agent](https://github.com/openebs/device-localpv/blob/91f34ce52fc6ae3696c84a08cf98e9e2f7378b04/pkg/device/device-util.go#L291).

Fixes #38 