### PR TITLE
fix(endpoints-discovery): Fixed device node driver service endpoints discovery

### DIFF
--- a/deploy/device-operator.yaml
+++ b/deploy/device-operator.yaml
@@ -245,9 +245,9 @@ apiVersion: v1
 kind: Service
 metadata:
   name: openebs-device-node-service
+  namespace: kube-system
   labels:
     name: openebs-device-node
-  namespace: kube-system
 spec:
   clusterIP: None
   ports:

--- a/deploy/device-operator.yaml
+++ b/deploy/device-operator.yaml
@@ -247,6 +247,7 @@ metadata:
   name: openebs-device-node-service
   labels:
     name: openebs-device-node
+  namespace: kube-system
 spec:
   clusterIP: None
   ports:

--- a/deploy/yamls/device-driver.yaml
+++ b/deploy/yamls/device-driver.yaml
@@ -7,6 +7,7 @@ metadata:
   name: openebs-device-node-service
   labels:
     name: openebs-device-node
+  namespace: kube-system
 spec:
   clusterIP: None
   ports:

--- a/deploy/yamls/device-driver.yaml
+++ b/deploy/yamls/device-driver.yaml
@@ -5,9 +5,9 @@ apiVersion: v1
 kind: Service
 metadata:
   name: openebs-device-node-service
+  namespace: kube-system
   labels:
     name: openebs-device-node
-  namespace: kube-system
 spec:
   clusterIP: None
   ports:


### PR DESCRIPTION
Signed-off-by: Abhishek Agarwal <abhishek.agarwal@mayadata.io>

**Why is this PR required? What issue does it fix?**:
The device-node-driver service were not be to discover/identify the endpoints because of being installed in different ns then the device driver daemonset through operator.

**What this PR does?**:
This PR adds namespace field in the metadata section to the service same as the namespace in which the device driver daemonset  is installed to that the service is able to successfully identify its endpoints.
