### PR TITLE
chore(ci): add GHCR build and push steps to build.yml and release.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -150,6 +150,7 @@ jobs:
           images: |
             ${{ env.IMAGE_ORG }}/device-driver
             quay.io/${{ env.IMAGE_ORG }}/device-driver
+            ghcr.io/${{ env.IMAGE_ORG }}/device-driver
           tag-latest: false
           tag-custom-only: true
           tag-custom: |
@@ -183,6 +184,13 @@ jobs:
           registry: quay.io
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_TOKEN }}
+
+      - name: Login to GHCR
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build & Push Image
         uses: docker/build-push-action@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,6 +52,7 @@ jobs:
           images: |
             ${{ env.IMAGE_ORG }}/device-driver
             quay.io/${{ env.IMAGE_ORG }}/device-driver
+            ghcr.io/${{ env.IMAGE_ORG }}/device-driver
           tag-latest: true
           tag-semver: |
             {{version}}
@@ -84,6 +85,13 @@ jobs:
           registry: quay.io
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_TOKEN }}
+
+      - name: Login to GHCR
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build & Push Image
         uses: docker/build-push-action@v2


### PR DESCRIPTION
Signed-off-by: Niladri Halder <niladri.halder@mayadata.io>

This adds Github Actions CI instructions to push built images to GHCR image registry.