### PR TITLE
Ignore specific Block Devices using Regular Expression

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -88,7 +88,7 @@ func main() {
 	)
 
 	cmd.PersistentFlags().StringVar(
-		&config.IgnoreBlockDevicesRegex, "ignore-block-devices-regex", "", "Ignore the Stroage devices by specifying the matching Regular Expression",
+		&config.IgnoreBlockDevicesRegex, "ignore-block-devices-regex", "", "Ignore the block devices by specifying the matching regular expression",
 	)
 
 	err := cmd.Execute()
@@ -113,7 +113,7 @@ func run(config *config.Config) {
 	)
 
 	if len(config.IgnoreBlockDevicesRegex) > 0 {
-		device.IgnoreBlockDevicesRegex = regexp.MustCompile(config.IgnoreBlockDevicesRegex)
+		device.DeviceConfiguration.IgnoreBlockDevicesRegex = regexp.MustCompile(config.IgnoreBlockDevicesRegex)
 	}
 
 	err := driver.New(config).Run()

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"regexp"
 
 	config "github.com/openebs/device-localpv/pkg/config"
 	"github.com/openebs/device-localpv/pkg/device"
@@ -86,6 +87,10 @@ func main() {
 		&config.DisableExporterMetrics, "disable-exporter-metrics", true, "Excludes additional process or go runtime related metrics (i.e process_*, go_*). Default is true.",
 	)
 
+	cmd.PersistentFlags().StringVar(
+		&config.IgnoreBlockDevicesRegex, "ignore-block-devices-regex", "", "Ignore the Stroage devices by specifying the matching Regular Expression",
+	)
+
 	err := cmd.Execute()
 	if err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "%s", err.Error())
@@ -106,6 +111,10 @@ func run(config *config.Config) {
 		config.Endpoint,
 		config.NodeID,
 	)
+
+	if len(config.IgnoreBlockDevicesRegex) > 0 {
+		device.IgnoreBlockDevicesRegex = regexp.MustCompile(config.IgnoreBlockDevicesRegex)
+	}
 
 	err := driver.New(config).Run()
 	if err != nil {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -54,6 +54,9 @@ type Config struct {
 	// Excludes additional process or go runtime related metrics (i.e process_*, go_*).
 	// Default is true
 	DisableExporterMetrics bool
+
+	// Ignore the Block devices by specifying the matching Regular Expression
+	IgnoreBlockDevicesRegex string
 }
 
 // Default returns a new instance of config

--- a/pkg/device/device-util.go
+++ b/pkg/device/device-util.go
@@ -32,6 +32,9 @@ import (
 	apis "github.com/openebs/device-localpv/pkg/apis/openebs.io/device/v1alpha1"
 )
 
+// Compiled Regex to Ignore the Block devices
+var IgnoreBlockDevicesRegex *regexp.Regexp = nil
+
 // Partition Commands
 const (
 	PartitionDiskID    = "fdisk -l /dev/%s"
@@ -499,6 +502,9 @@ func getDiskList() ([]diskDetail, error) {
 		// sdb        8:16   0 17179869184  0 disk
 		tmp := strings.Fields(blockDeviceEntry)
 		if len(tmp) <= lsblkDevTypeIndex {
+			continue
+		}
+		if IgnoreBlockDevicesRegex != nil && IgnoreBlockDevicesRegex.MatchString(tmp[lsblkNameIndex]) {
 			continue
 		}
 

--- a/pkg/device/device-util.go
+++ b/pkg/device/device-util.go
@@ -32,9 +32,6 @@ import (
 	apis "github.com/openebs/device-localpv/pkg/apis/openebs.io/device/v1alpha1"
 )
 
-// Compiled Regex to Ignore the Block devices
-var IgnoreBlockDevicesRegex *regexp.Regexp = nil
-
 // Partition Commands
 const (
 	PartitionDiskID    = "fdisk -l /dev/%s"
@@ -504,7 +501,7 @@ func getDiskList() ([]diskDetail, error) {
 		if len(tmp) <= lsblkDevTypeIndex {
 			continue
 		}
-		if IgnoreBlockDevicesRegex != nil && IgnoreBlockDevicesRegex.MatchString(tmp[lsblkNameIndex]) {
+		if DeviceConfiguration.IgnoreBlockDevicesRegex != nil && DeviceConfiguration.IgnoreBlockDevicesRegex.MatchString(tmp[lsblkNameIndex]) {
 			continue
 		}
 

--- a/pkg/device/volume.go
+++ b/pkg/device/volume.go
@@ -17,6 +17,7 @@ package device
 import (
 	"context"
 	"os"
+	"regexp"
 	"time"
 
 	"google.golang.org/grpc/codes"
@@ -28,6 +29,11 @@ import (
 	apis "github.com/openebs/device-localpv/pkg/apis/openebs.io/device/v1alpha1"
 	"github.com/openebs/device-localpv/pkg/builder/volbuilder"
 )
+
+type DeviceConfig struct {
+	// Compiled Regex to Ignore the Block devices
+	IgnoreBlockDevicesRegex *regexp.Regexp
+}
 
 const (
 	// DeviceNamespaceKey is the environment variable to get openebs namespace
@@ -65,6 +71,9 @@ var (
 
 	// GoogleAnalyticsEnabled should send google analytics or not
 	GoogleAnalyticsEnabled string
+
+	//
+	DeviceConfiguration *DeviceConfig
 )
 
 func init() {
@@ -79,6 +88,8 @@ func init() {
 	}
 
 	GoogleAnalyticsEnabled = os.Getenv(GoogleAnalyticsKey)
+
+	DeviceConfiguration = &DeviceConfig{}
 }
 
 // ProvisionVolume creates a DeviceVolume CR,


### PR DESCRIPTION
We are adding the capability in the plugin to Ignore certain block devices, We need to pass the commandline Argument  **ignore-block-devices-regex** with regular expression matching the block device name that we want to ignore